### PR TITLE
ci: remove custom lint job

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,8 +17,6 @@ permissions:
   contents: read
 
 jobs:
-  lint:
-    uses: ./.github/workflows/lint.yml
   test:
     uses: ./.github/workflows/test.yml
   docs:
@@ -28,11 +26,10 @@ jobs:
   required-checks-pass:
     if: always()
     needs:
-    - lint
     - test
     - docs
     runs-on: ubuntu-22.04
     steps:
-    - uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe   # v1.2.2
+    - uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
       with:
         jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
## Description

Since pre-commi.ci runs on PRs, no need for the custom lint job.

## Types of changes

- Other (please describe):

## Checklist
<!--- Go over all the following points, and remove the lines, that do not apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- I have read the [contributor guide](https://github.com/afuetterer/oaipmh-scythe/blob/main/.github/CONTRIBUTING.md).
- My code follows the code style of this project.
- My change requires a change to the documentation.
- I have updated the documentation accordingly.
- I have added tests to cover my changes.

<!--- This pull request template is adapted from:
<!--- "open-source-templates", https://github.com/TalAter/open-source-templates (MIT License). --->
<!--- "amazing-github-template", https://github.com/dec0dOS/amazing-github-template (MIT License). --->
