### PR TITLE
refactor: rename exceptions

### DIFF
--- a/src/oaipmh_scythe/exceptions.py
+++ b/src/oaipmh_scythe/exceptions.py
@@ -5,44 +5,44 @@
 """Custom exceptions for OAI-PMH related errors."""
 
 
-class OAIPMHError(Exception):
+class OAIPMHException(Exception):
     """Base exception for all OAI-PMH related errors."""
 
 
-class BadArgument(OAIPMHError):
+class BadArgument(OAIPMHException):
     """The request includes illegal arguments, is missing required arguments, includes a repeated argument,
     or values for arguments have an illegal syntax."""
 
 
-class BadVerb(OAIPMHError):
+class BadVerb(OAIPMHException):
     """Value of the verb argument is not a legal OAI-PMH verb, the verb argument is missing,
     or the verb argument is repeated."""
 
 
-class BadResumptionToken(OAIPMHError):
+class BadResumptionToken(OAIPMHException):
     """The value of the resumptionToken argument is invalid or expired."""
 
 
-class CannotDisseminateFormat(OAIPMHError):
+class CannotDisseminateFormat(OAIPMHException):
     """The metadata format identified by the value given for the metadataPrefix argument
     is not supported by the item or by the repository."""
 
 
-class IdDoesNotExist(OAIPMHError):
+class IdDoesNotExist(OAIPMHException):
     """The value of the identifier argument is unknown or illegal in this repository."""
 
 
-class NoSetHierarchy(OAIPMHError):
+class NoSetHierarchy(OAIPMHException):
     """The repository does not support sets."""
 
 
-class NoMetadataFormat(OAIPMHError):
+class NoMetadataFormat(OAIPMHException):
     """There are no metadata formats available for the specified item."""
 
 
-class NoRecordsMatch(OAIPMHError):
+class NoRecordsMatch(OAIPMHException):
     """The combination of the values of the from, until, set and metadataPrefix arguments results in an empty list."""
 
 
-class OAIError(OAIPMHError):
-    """Context specific OAI errors not covered by the classes above."""
+class GeneralOAIPMHError(OAIPMHException):
+    """General exception for context-specific OAI-PMH errors not covered by the other specific classes."""

--- a/src/oaipmh_scythe/iterator.py
+++ b/src/oaipmh_scythe/iterator.py
@@ -81,7 +81,7 @@ class BaseOAIIterator(ABC):
                 exception_name = code[0].upper() + code[1:]
                 raise getattr(exceptions, exception_name)(description)
             except AttributeError as exc:
-                raise exceptions.OAIError(description) from exc
+                raise exceptions.GeneralOAIPMHError(description) from exc
         self.resumption_token = self._get_resumption_token()
 
 


### PR DESCRIPTION
## Description

This change makes it a little bit easier to distinguish between `OAIPMHError` and the general `OAIError`. The names were too similar.

## Types of changes

- Refactoring (no functional changes, no API changes)

## Checklist
<!--- Go over all the following points, and remove the lines, that do not apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- I have read the [contributor guide](https://github.com/afuetterer/oaipmh-scythe/blob/main/.github/CONTRIBUTING.md).
- My code follows the code style of this project.
