### PR TITLE
refactor: rename scythe module to client

### DIFF
--- a/docs/api/client.md
+++ b/docs/api/client.md
@@ -1,3 +1,3 @@
-::: oaipmh_scythe.scythe.Scythe
+::: oaipmh_scythe.client.Scythe
     options:
         show_root_heading: true

--- a/docs/customizing.md
+++ b/docs/customizing.md
@@ -21,8 +21,8 @@ class MyRecord(Record):
     Take a look at the implementation of [oaipmh_scythe.models.Record][] to get an idea of
     how to do this.
 
-Next, associate your implementation with OAI verbs in the [oaipmh_scythe.scythe.Scythe][] object.
-In this case, we want the [oaipmh_scythe.scythe.Scythe][] object to use our implementation to represent items returned by
+Next, associate your implementation with OAI verbs in the [oaipmh_scythe.client.Scythe][] object.
+In this case, we want the [oaipmh_scythe.client.Scythe][] object to use our implementation to represent items returned by
 ListRecords and GetRecord responses:
 
 ```python
@@ -32,7 +32,7 @@ scythe.class_mapping['GetRecord'] = MyRecord
 ```
 
 If you need to rewrite *all* item implementations, you can also provide
-a complete mapping to the [oaipmh_scythe.scythe.Scythe][] object at instantiation:
+a complete mapping to the [oaipmh_scythe.client.Scythe][] object at instantiation:
 
 ```python
 my_mapping = {

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -50,9 +50,9 @@ next(records)
 ```
 
 Note that this works with all verbs that return more than one element.
-These are: [list_records()][oaipmh_scythe.scythe.Scythe.list_records],
-[list_identifiers()][oaipmh_scythe.scythe.Scythe.list_identifiers], [list_sets()][oaipmh_scythe.scythe.Scythe.list_sets],
-and [list_metadata_formats()][oaipmh_scythe.scythe.Scythe.list_metadata_formats].
+These are: [list_records()][oaipmh_scythe.client.Scythe.list_records],
+[list_identifiers()][oaipmh_scythe.client.Scythe.list_identifiers], [list_sets()][oaipmh_scythe.client.Scythe.list_sets],
+and [list_metadata_formats()][oaipmh_scythe.client.Scythe.list_metadata_formats].
 
 The following example shows how to iterate over the headers returned by
 `list_identifiers()`:
@@ -107,7 +107,7 @@ returned objects. The default mode returns OAI-specific *items*
 (records, headers etc.) encoded as Python objects as seen earlier. If
 you want to save the whole XML response returned by the server, you have
 to pass the [OAIResponseIterator][oaipmh_scythe.iterator.OAIResponseIterator] during the instantiation of the
-[Scythe][oaipmh_scythe.scythe.Scythe] object:
+[Scythe][oaipmh_scythe.client.Scythe] object:
 
 ```python
 from oaipmh_scythe.iterator import OAIResponseIterator
@@ -126,8 +126,8 @@ with open("response.xml", "w") as f:
 
 ## Ignoring Deleted Records
 
-The [list_records()][oaipmh_scythe.scythe.Scythe.list_records] and
-[list_identifiers()][oaipmh_scythe.scythe.Scythe.list_identifiers] methods accept an optional parameter `ignore_deleted`.
+The [list_records()][oaipmh_scythe.client.Scythe.list_records] and
+[list_identifiers()][oaipmh_scythe.client.Scythe.list_identifiers] methods accept an optional parameter `ignore_deleted`.
 If set to `True`, the returned [OAIItemIterator][oaipmh_scythe.iterator.OAIItemIterator] will skip deleted records/headers:
 
 ```python

--- a/src/oaipmh_scythe/__init__.py
+++ b/src/oaipmh_scythe/__init__.py
@@ -3,10 +3,10 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-"""oaipmh-scythe. OAI-PMH for Humans."""
+"""oaipmh-scythe: A Scythe for harvesting OAI-PMH repositories."""
 
+from oaipmh_scythe.client import Scythe
 from oaipmh_scythe.response import OAIResponse
-from oaipmh_scythe.scythe import Scythe
 
 __all__ = [
     "Scythe",

--- a/src/oaipmh_scythe/client.py
+++ b/src/oaipmh_scythe/client.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-"""The scythe module provides a client interface for interacting with OAI-PMH services.
+"""The client module provides a client interface for interacting with OAI-PMH services.
 
 This module defines the Scythe class, which facilitates the harvesting of records, identifiers, and sets
 from OAI-PMH compliant repositories. It handles various OAI-PMH requests, manages pagination with resumption tokens,


### PR DESCRIPTION
## Description

Rename the scythe module (again) to `client.py`, which is more explicit.

## Types of changes

- Refactoring (no functional changes, no API changes)

## Checklist
<!--- Go over all the following points, and remove the lines, that do not apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- I have read the [contributor guide](https://github.com/afuetterer/oaipmh-scythe/blob/main/.github/CONTRIBUTING.md).
- My code follows the code style of this project.
- My change requires a change to the documentation.
- I have updated the documentation accordingly.
- I have added tests to cover my changes.

<!--- This pull request template is adapted from:
<!--- "open-source-templates", https://github.com/TalAter/open-source-templates (MIT License). --->
<!--- "amazing-github-template", https://github.com/dec0dOS/amazing-github-template (MIT License). --->
