### PR TITLE
ci: fix publish package to release step

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,4 +44,3 @@ jobs:
       if: ${{ steps.release.outputs.released }} == 'true'
       with:
         github_token: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
-        tag: ${{ steps.release.outputs.tag }}


### PR DESCRIPTION
## Description

There was an error when trying to upload the built distribution and wheel to the newly created GitHub release. The tag was not found. The tag parameter defaults to `latest`, which actually fixes the problem. The latest tag is the newly created one by the previous step.
