### PR TITLE
refactor(client): remove obsolete is_error_code()

### DIFF
--- a/src/oaipmh_scythe/client.py
+++ b/src/oaipmh_scythe/client.py
@@ -163,7 +163,7 @@ class Scythe:
         """
         http_response = self._request(kwargs)
         for _ in range(self.max_retries):
-            if self._is_error_code(http_response.status_code) and http_response.status_code in self.retry_status_codes:
+            if httpx.codes.is_error(http_response.status_code) and http_response.status_code in self.retry_status_codes:
                 retry_after = self.get_retry_after(http_response)
                 logger.warning("HTTP %d! Retrying after %d seconds..." % (http_response.status_code, retry_after))
                 time.sleep(retry_after)
@@ -293,18 +293,3 @@ class Scythe:
             except TypeError:
                 return self.default_retry_after
         return self.default_retry_after
-
-    @staticmethod
-    def _is_error_code(status_code: int) -> bool:
-        """Check if the given status code represents an error.
-
-        Determine whether the provided HTTP status code is indicative of an error condition.
-        In general, any status code equal to or greater than 400 is considered an error.
-
-        Args:
-            status_code: The HTTP status code to evaluate.
-
-        Returns:
-            A boolean indicating whether the status code represents an error.
-        """
-        return status_code >= 400

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -48,11 +48,6 @@ def test_context_manager() -> None:
         assert isinstance(scythe, Scythe)
 
 
-def test_wrong_is_error_code(scythe: Scythe) -> None:
-    assert not scythe._is_error_code(200)
-    assert scythe._is_error_code(400)
-
-
 def test_override_encoding(scythe: Scythe, respx_mock: MockRouter) -> None:
     mock_route = respx_mock.get("https://zenodo.org/oai2d?metadataPrefix=oai_dc&verb=ListIdentifiers").mock(
         return_value=httpx.Response(200)


### PR DESCRIPTION
## Description

httpx actually has a method to test if a http status code is an error. Let's use that one and keep the client smaller.
