### PR TITLE
build: enable mdformat pre-commit hook

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -2,15 +2,12 @@
 
 ## Our Pledge
 
-We as members, contributors, and leaders pledge to make participation in our
-community a harassment-free experience for everyone, regardless of age, body
-size, visible or invisible disability, ethnicity, sex characteristics, gender
-identity and expression, level of experience, education, socio-economic status,
-nationality, personal appearance, race, caste, color, religion, or sexual
-identity and orientation.
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for
+everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity
+and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste,
+color, religion, or sexual identity and orientation.
 
-We pledge to act and interact in ways that contribute to an open, welcoming,
-diverse, inclusive, and healthy community.
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
 
 ## Our Standards
 
@@ -19,103 +16,85 @@ Examples of behavior that contributes to a positive environment for our communit
 - Demonstrating empathy and kindness toward other people
 - Being respectful of differing opinions, viewpoints, and experiences
 - Giving and gracefully accepting constructive feedback
-- Accepting responsibility and apologizing to those affected by our mistakes,
-  and learning from the experience
-- Focusing on what is best not just for us as individuals, but for the overall
-  community
+- Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall community
 
 Examples of unacceptable behavior include:
 
-- The use of sexualized language or imagery, and sexual attention or advances of
-  any kind
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
 - Trolling, insulting or derogatory comments, and personal or political attacks
 - Public or private harassment
-- Publishing others' private information, such as a physical or email address,
-  without their explicit permission
-- Other conduct which could reasonably be considered inappropriate in a
-  professional setting
+- Publishing others' private information, such as a physical or email address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
 
 ## Enforcement Responsibilities
 
-Community leaders are responsible for clarifying and enforcing our standards of
-acceptable behavior and will take appropriate and fair corrective action in
-response to any behavior that they deem inappropriate, threatening, offensive,
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take
+appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive,
 or harmful.
 
-Community leaders have the right and responsibility to remove, edit, or reject
-comments, commits, code, wiki edits, issues, and other contributions that are
-not aligned to this Code of Conduct, and will communicate reasons for moderation
-decisions when appropriate.
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits,
+issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for
+moderation decisions when appropriate.
 
 ## Scope
 
-This Code of Conduct applies within all community spaces, and also applies when
-an individual is officially representing the community in public spaces.
-Examples of representing our community include using an official e-mail address,
-posting via an official social media account, or acting as an appointed
-representative at an online or offline event.
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing
+the community in public spaces. Examples of representing our community include using an official e-mail address, posting
+via an official social media account, or acting as an appointed representative at an online or offline event.
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement at [@afuetterer](https://github.com/afuetterer).
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible
+for enforcement at [@afuetterer](https://github.com/afuetterer).
 
 All complaints will be reviewed and investigated promptly and fairly.
 
-All community leaders are obligated to respect the privacy and security of the
-reporter of any incident.
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
 
 ## Enforcement Guidelines
 
-Community leaders will follow these Community Impact Guidelines in determining
-the consequences for any action they deem in violation of this Code of Conduct:
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem
+in violation of this Code of Conduct:
 
 ### 1. Correction
 
-**Community Impact**: Use of inappropriate language or other behavior deemed
-unprofessional or unwelcome in the community.
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the
+community.
 
-**Consequence**: A private, written warning from community leaders, providing
-clarity around the nature of the violation and an explanation of why the
-behavior was inappropriate. A public apology may be requested.
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation
+and an explanation of why the behavior was inappropriate. A public apology may be requested.
 
 ### 2. Warning
 
 **Community Impact**: A violation through a single incident or series of actions.
 
-**Consequence**: A warning with consequences for continued behavior. No
-interaction with the people involved, including unsolicited interaction with
-those enforcing the Code of Conduct, for a specified period of time. This
-includes avoiding interactions in community spaces as well as external channels
-like social media. Violating these terms may lead to a temporary or permanent
-ban.
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including
+unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding
+interactions in community spaces as well as external channels like social media. Violating these terms may lead to a
+temporary or permanent ban.
 
 ### 3. Temporary Ban
 
-**Community Impact**: A serious violation of community standards, including
-sustained inappropriate behavior.
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
 
-**Consequence**: A temporary ban from any sort of interaction or public
-communication with the community for a specified period of time. No public or
-private interaction with the people involved, including unsolicited interaction
-with those enforcing the Code of Conduct, is allowed during this period.
-Violating these terms may lead to a permanent ban.
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified
+period of time. No public or private interaction with the people involved, including unsolicited interaction with those
+enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
 
 ### 4. Permanent Ban
 
-**Community Impact**: Demonstrating a pattern of violation of community
-standards, including sustained inappropriate behavior, harassment of an
-individual, or aggression toward or disparagement of classes of individuals.
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate
+behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
 
-**Consequence**: A permanent ban from any sort of public interaction within the
-community.
+**Consequence**: A permanent ban from any sort of public interaction within the community.
 
 ## Attribution
 
 *This Code of Conduct is adapted from [cookiecutter-hypermodern-python (MIT License)][hypermodern-python-coc].*
 
-The cookiecutter-hypermodern-python version is originally adapted from the [Contributor Covenant][homepage],
-version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+The cookiecutter-hypermodern-python version is originally adapted from the [Contributor Covenant][homepage], version
+2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
 
 Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][mozilla coc].
 
@@ -123,10 +102,11 @@ For answers to common questions about this code of conduct, see the FAQ at
 [https://www.contributor-covenant.org/faq][faq]. Translations are available at
 [https://www.contributor-covenant.org/translations][translations].
 
-<!-- Markdown links -->
-[hypermodern-python-coc]: https://github.com/cjolowicz/cookiecutter-hypermodern-python/blob/main/%7B%7Bcookiecutter.project_name%7D%7D/CODE_OF_CONDUCT.md
-[homepage]: https://www.contributor-covenant.org
-[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
-[mozilla coc]: https://github.com/mozilla/diversity
+<!-- Refs -->
+
 [faq]: https://www.contributor-covenant.org/faq
+[homepage]: https://www.contributor-covenant.org
+[hypermodern-python-coc]: https://github.com/cjolowicz/cookiecutter-hypermodern-python/blob/main/%7B%7Bcookiecutter.project_name%7D%7D/CODE_OF_CONDUCT.md
+[mozilla coc]: https://github.com/mozilla/diversity
 [translations]: https://www.contributor-covenant.org/translations
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -12,39 +12,41 @@ Report bugs at https://github.com/afuetterer/oaipmh-scythe/issues.
 
 If you are reporting a bug, please include:
 
-* Your operating system name and version.
-* Any details about your local setup that might be helpful in troubleshooting.
-* Detailed steps to reproduce the bug.
+- Your operating system name and version.
+- Any details about your local setup that might be helpful in troubleshooting.
+- Detailed steps to reproduce the bug.
 
 ### Fix Bugs
 
-Look through the GitHub issues for bugs. Anything tagged with [bug][bug-issues] and [help wanted][help-wanted-issues] is open to whoever wants to implement it.
+Look through the GitHub issues for bugs. Anything tagged with [bug][bug-issues] and [help wanted][help-wanted-issues] is
+open to whoever wants to implement it.
 
 ### Implement Features
 
-Look through the GitHub issues for features. Anything tagged with [feature][feature-issues] and [help wanted][help-wanted-issues] is open to whoever wants to implement it.
+Look through the GitHub issues for features. Anything tagged with [feature][feature-issues] and
+[help wanted][help-wanted-issues] is open to whoever wants to implement it.
 
 ### Write Documentation
 
-oaipmh-scythe could always use more documentation, whether as part of the official oaipmh-scythe docs, in docstrings,
-or even on the web in blog posts, articles, and such.
+oaipmh-scythe could always use more documentation, whether as part of the official oaipmh-scythe docs, in docstrings, or
+even on the web in blog posts, articles, and such.
 
 ### Submit Feedback
 
-The best way to send feedback is to file an issue at https://github.com/afuetterer/oaipmh-scythe/issues.
+The best way to send feedback is to file an issue at <https://github.com/afuetterer/oaipmh-scythe/issues>.
 
 If you are proposing a feature:
 
-* Explain in detail how it would work.
-* Keep the scope as narrow as possible, to make it easier to implement.
-* Remember that this is a volunteer-driven project, and that contributions
-  are welcome.
+- Explain in detail how it would work.
+- Keep the scope as narrow as possible, to make it easier to implement.
+- Remember that this is a volunteer-driven project, and that contributions are welcome.
 
 ## Get Started!
 
 Ready to contribute?
 
-You need Python 3.10+ and [hatch](https://github.com/pypa/hatch). You can install it globally with [pipx](https://github.com/pypa/pipx):
+You need Python 3.10+ and [hatch](https://github.com/pypa/hatch). You can install it globally with
+[pipx](https://github.com/pypa/pipx):
 
 ```console
 $ pipx install hatch
@@ -59,30 +61,39 @@ $ pip install hatch
 Here's how to set up oaipmh-scythe for local development.
 
 1. Fork the oaipmh-scythe repository on GitHub.
+
 2. Clone your fork locally:
+
     ```console
     $ git clone git@github.com:username/oaipmh-scythe.git
     ```
-3. Install your local copy into a virtual environment. Assuming you have hatch installed, this is how you set up your fork for local development:
+
+3. Install your local copy into a virtual environment. Assuming you have hatch installed, this is how you set up your
+    fork for local development:
+
     ```console
     $ cd oaipmh-scythe
     $ hatch shell
     $ pre-commit install
     ```
+
 4. Create a branch for local development:
+
     ```console
     $ git checkout -b name-of-your-bugfix-or-feature
     ```
-   Now you can make your changes locally.
 
-5. When you're done making changes, check that your changes pass pre-commit and the
-   tests:
+    Now you can make your changes locally.
+
+5. When you're done making changes, check that your changes pass pre-commit and the tests:
+
     ```console
     $ hatch run lint:all
     $ hatch run cov
     ```
 
 6. Commit your changes and push your branch to GitHub::
+
     ```console
     $ git add .
     $ git commit -m "Your detailed description of your changes."
@@ -96,17 +107,18 @@ Here's how to set up oaipmh-scythe for local development.
 Before you submit a pull request, check that it meets these guidelines:
 
 1. The pull request should include tests.
-2. If the pull request adds functionality, the docs should be updated. Put
-   your new functionality into a function with a docstring.
-3. The pull request should work for Python >= 3.10. Check
-   https://github.com/afuetterer/oaipmh-scythe/pulls
-   and make sure that all the tests pass.
+2. If the pull request adds functionality, the docs should be updated. Put your new functionality into a function with a
+    docstring.
+3. The pull request should work for Python >= 3.10. Check https://github.com/afuetterer/oaipmh-scythe/pulls and make
+    sure that all the tests pass.
 
 ---
 
-*This contributor guide is adapted from [cookiecutter-pypackage (BSD 3-Clause License)](https://github.com/audreyfeldroy/cookiecutter-pypackage/blob/master/%7B%7Bcookiecutter.project_slug%7D%7D/CONTRIBUTING.rst).*
+*This contributor guide is adapted from
+[cookiecutter-pypackage (BSD 3-Clause License)](https://github.com/audreyfeldroy/cookiecutter-pypackage/blob/master/%7B%7Bcookiecutter.project_slug%7D%7D/CONTRIBUTING.rst).*
 
-<!-- Markdown links -->
+<!-- Refs -->
+
 [bug-issues]: https://github.com/afuetterer/oaipmh-scythe/labels/type%3A%20bug
 [feature-issues]: https://github.com/afuetterer/oaipmh-scythe/labels/type%3A%20feature
 [help-wanted-issues]: https://github.com/afuetterer/oaipmh-scythe/labels/help%20wanted

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,39 +1,51 @@
 ---
 name: Bug report
 about: Create a bug report to help us improve
-labels: ["type: bug"]
+labels: ['type: bug']
 ---
 
 <!--- Provide a general summary of the issue in the Title above --->
 
 ## Description
+
 <!--- Provide a more detailed introduction to the issue itself, and why you consider it to be a bug --->
 
 ## Expected Behavior
+
 <!--- Tell us what should happen --->
 
 ## Actual Behavior
+
 <!--- Tell us what happens instead --->
 
 ## Possible Fix
+
 <!--- Not obligatory, but suggest a fix or reason for the bug --->
 
 ## Steps to reproduce
-<!--- Provide a link to a live example, or an unambiguous set of steps to --->
-<!--- reproduce this bug. Include code to reproduce, if relevant --->
+
+<!---
+Provide a link to a live example, or an unambiguous set of steps to
+reproduce this bug. Include code to reproduce, if relevant
+--->
+
 1.
 2.
 3.
 
 ## Additional Context
+
 <!--- How has this bug affected you? What were you trying to accomplish? --->
 
 ## Your Environment
+
 <!--- Please provide the output of the following commands. --->
 
 - Python version used (`python --version`):
 - oaipmh-scythe version used (`python -m pip show oaipmh-scythe | grep "^Version:"`):
 - Operating system and version:
 
-<!--- This issue template is adapted from:
-<!--- "open-source-templates", https://github.com/TalAter/open-source-templates (MIT License). --->
+<!---
+This issue template is adapted from:
+"open-source-templates", https://github.com/TalAter/open-source-templates (MIT License).
+--->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,20 +1,27 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-labels: ["type: feature"]
+labels: ['type: feature']
 ---
 
-<!--- Provide a general summary of the issue in the Title above -->
+<!--- Provide a general summary of the issue in the Title above --->
 
 ## Detailed Description
-<!--- Provide a detailed description of the change or addition you are proposing -->
+
+<!--- Provide a detailed description of the change or addition you are proposing --->
 
 ## Context
-<!--- Why is this change important to you? How would you use it? -->
-<!--- How can it benefit other users? -->
+
+<!---
+Why is this change important to you? How would you use it?
+How can it benefit other users?
+--->
 
 ## Possible Implementation
-<!--- Not obligatory, but suggest an idea for implementing addition or change -->
 
-<!--- This issue template is adapted from:
-<!--- "open-source-templates", https://github.com/TalAter/open-source-templates (MIT License). --->
+<!--- Not obligatory, but suggest an idea for implementing addition or change --->
+
+<!---
+This issue template is adapted from:
+"open-source-templates", https://github.com/TalAter/open-source-templates (MIT License).
+--->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,27 +1,37 @@
-<!-- These comments are hidden when you submit the pull request, so you do not need to remove them. -->
+<!-- These comments are hidden when you submit the pull request, so you do not need to remove them. --->
 
 <!--- Provide a general summary of your changes in the Title above --->
 
 ## Description
-<!--- Describe your changes in detail --->
 
-<!--- This project only accepts pull requests related to open issues --->
-<!--- If suggesting a new feature or change, please discuss it in an issue first --->
-<!--- If fixing a bug, there should be an issue describing it with steps to reproduce --->
-<!--- Please link to the issue here: --->
+<!---
+Describe your changes in detail
+
+This project only accepts pull requests related to open issues
+If suggesting a new feature or change, please discuss it in an issue first
+If fixing a bug, there should be an issue describing it with steps to reproduce
+Please link to the issue here:
+--->
+
 Related issue: #ISSUE_NUMBER
 
 ## Motivation and context
+
 <!--- Why is this change required? What problem does it solve? --->
 
 ## How has this been tested?
-<!--- Please describe in detail how you tested your changes. --->
-<!--- Include details of your testing environment, and the tests you ran to --->
-<!--- see how your change affects other areas of the code, etc. --->
+
+<!---
+Please describe in detail how you tested your changes.
+
+Include details of your testing environment, and the tests you ran to
+see how your change affects other areas of the code, etc.
+--->
 
 ## Types of changes
 
 <!--- What types of changes does your code introduce? Remove the lines, that do not apply. --->
+
 - Breaking change (fix or feature that would cause existing functionality to change)
 - New feature (non-breaking change which adds functionality)
 - Bug fix (non-breaking change which fixes an issue)
@@ -35,14 +45,20 @@ Related issue: #ISSUE_NUMBER
 - Other (please describe):
 
 ## Checklist
-<!--- Go over all the following points, and remove the lines, that do not apply. --->
-<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
+
+<!---
+Go over all the following points, and remove the lines, that do not apply.
+If you're unsure about any of these, don't hesitate to ask. We're here to help!
+--->
+
 - I have read the [contributor guide](https://github.com/afuetterer/oaipmh-scythe/blob/main/.github/CONTRIBUTING.md).
 - My code follows the code style of this project.
 - My change requires a change to the documentation.
 - I have updated the documentation accordingly.
 - I have added tests to cover my changes.
 
-<!--- This pull request template is adapted from:
-<!--- "open-source-templates", https://github.com/TalAter/open-source-templates (MIT License). --->
-<!--- "amazing-github-template", https://github.com/dec0dOS/amazing-github-template (MIT License). --->
+<!---
+This pull request template is adapted from:
+"open-source-templates", https://github.com/TalAter/open-source-templates (MIT License).
+"amazing-github-template", https://github.com/dec0dOS/amazing-github-template (MIT License).
+--->

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -2,14 +2,18 @@
 
 ## Supported Versions
 
-Only the latest version of oaipmh-scythe will receive security updates. Previous versions of the project will not receive patches or security improvements. Users are encouraged to update to the latest version as soon as it is available.
+Only the latest version of oaipmh-scythe will receive security updates. Previous versions of the project will not
+receive patches or security improvements. Users are encouraged to update to the latest version as soon as it is
+available.
 
 ## Reporting a Vulnerability
 
 To report a security vulnerability, please follow these steps:
 
-- To report a security issue, please use the GitHub Security Advisory [Report a Vulnerability](https://github.com/afuetterer/oaipmh-scythe/security/advisories/new) tab.
-- Provide a clear and detailed account of the vulnerability, including the potential impact and steps required to reproduce it.
+- To report a security issue, please use the GitHub Security Advisory
+    [Report a Vulnerability](https://github.com/afuetterer/oaipmh-scythe/security/advisories/new) tab.
+- Provide a clear and detailed account of the vulnerability, including the potential impact and steps required to
+    reproduce it.
 
 Do not report security vulnerabilities through public GitHub issues.
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,6 +50,15 @@ repos:
   hooks:
   - id: pyproject-fmt
 
+- repo: https://github.com/executablebooks/mdformat
+  rev: 08fba30538869a440b5059de90af03e3502e35fb  # frozen: 0.7.17
+  hooks:
+  - id: mdformat
+    args: [--number, --wrap=120, --ignore-missing-references]
+    exclude: CHANGELOG.md|.changelog.md|docs/api
+    additional_dependencies:
+    - mdformat-mkdocs[recommended]>=v2.0.7
+
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: c22645f6b45188216151a407c040a9eec1795ab0  # frozen: v0.3.3
   hooks:

--- a/README.md
+++ b/README.md
@@ -3,17 +3,18 @@
 Welcome to oaipmh-scythe, an updated and modernized version of the original [sickle](https://github.com/mloesch/sickle),
 now with additional features and ongoing maintenance.
 
-| __CI__ | [![pre-commit.ci status][pre-commit-ci-badge]][pre-commit-ci-status] [![ci][ci-badge]][ci-workflow] [![coverage][coverage-badge]][ci-workflow] |
-| :--- | :--- |
-| __Docs__ | [![docs][docs-badge]][docs-workflow] |
+| __CI__      | [![pre-commit.ci status][pre-commit-ci-badge]][pre-commit-ci-status] [![ci][ci-badge]][ci-workflow] [![coverage][coverage-badge]][ci-workflow]                                                                                        |
+| :---------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| __Docs__    | [![docs][docs-badge]][docs-workflow]                                                                                                                                                                                                  |
 | __Package__ | [![pypi-version][pypi-version-badge]][pypi-url] [![pypi-python-versions][pypi-python-versions-badge]][pypi-url] [![all-downloads][all-downloads-badge]][pepy-tech-url] [![monthly-downloads][monthly-downloads-badge]][pepy-tech-url] |
-| __Meta__ | [![OpenSSF Scorecard][scorecard-badge]][scorecard-url] [![hatch][hatch-badge]][hatch] [![ruff][ruff-badge]][ruff] [![mypy][mypy-badge]][mypy] [![License][license-badge]][license] |
+| __Meta__    | [![OpenSSF Scorecard][scorecard-badge]][scorecard-url] [![hatch][hatch-badge]][hatch] [![ruff][ruff-badge]][ruff] [![mypy][mypy-badge]][mypy] [![License][license-badge]][license]                                                    |
 
-oaipmh-scythe is a lightweight [OAI-PMH](http://www.openarchives.org/OAI/openarchivesprotocol.html)
-client library written in Python. It has been designed for conveniently retrieving data from OAI interfaces the Pythonic way:
+oaipmh-scythe is a lightweight [OAI-PMH](http://www.openarchives.org/OAI/openarchivesprotocol.html) client library
+written in Python. It has been designed for conveniently retrieving data from OAI interfaces the Pythonic way:
 
 ```python
 from oaipmh_scythe import Scythe
+
 with Scythe("https://zenodo.org/oai2d") as scythe:
     records = scythe.list_records()
     next(records)
@@ -24,7 +25,7 @@ with Scythe("https://zenodo.org/oai2d") as scythe:
 
 - Easy harvesting of OAI-compliant interfaces
 - Support for all six OAI verbs
-- Convenient object representations of OAI items (records, headers, sets, \...)
+- Convenient object representations of OAI items (records, headers, sets, ...)
 - Automatic de-serialization of Dublin Core-encoded metadata payloads to Python dictionaries
 - Option for ignoring deleted items
 
@@ -47,23 +48,26 @@ python -m pip install oaipmh-scythe
 
 ## Documentation
 
-The [documentation][docs-url] is made with [Material for MkDocs](https://github.com/squidfunk/mkdocs-material) and is hosted by [GitHub Pages](https://docs.github.com/en/pages).
+The [documentation][docs-url] is made with [Material for MkDocs](https://github.com/squidfunk/mkdocs-material) and is
+hosted by [GitHub Pages](https://docs.github.com/en/pages).
 
 ## Similar Projects
 
-There are a couple of similar projects available on [PyPI](https://pypi.org/search/?q=oai-pmh) and GitHub, e.g. via
-the topics [oai-pmh](https://github.com/topics/oai-pmh) and [oai-pmh-client](https://github.com/topics/oai-pmh-client). Among them are these implementations in Python:
+There are a couple of similar projects available on [PyPI](https://pypi.org/search/?q=oai-pmh) and GitHub, e.g. via the
+topics [oai-pmh](https://github.com/topics/oai-pmh) and [oai-pmh-client](https://github.com/topics/oai-pmh-client).
+Among them are these implementations in Python:
 
-| Project | Description | Last commit |
-| --- | --- |  --- |
-| [sickle](https://github.com/mloesch/sickle) | oaipmh-scythe is a fork of sickle | ![last-commit](https://img.shields.io/github/last-commit/mloesch/sickle) |
-| [pyoai](https://github.com/infrae/pyoai) | sickle was inspired by pyoai | ![last-commit](https://img.shields.io/github/last-commit/infrae/pyoai) |
-| [pyoaiharvester](https://github.com/vphill/pyoaiharvester) | oai-pmh harvester CLI | ![last-commit](https://img.shields.io/github/last-commit/vphill/pyoaiharvester) |
+| Project                                                                          | Description                        | Last commit                                                                                           |
+| -------------------------------------------------------------------------------- | ---------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| [sickle](https://github.com/mloesch/sickle)                                      | oaipmh-scythe is a fork of sickle  | ![last-commit](https://img.shields.io/github/last-commit/mloesch/sickle)                              |
+| [pyoai](https://github.com/infrae/pyoai)                                         | sickle was inspired by pyoai       | ![last-commit](https://img.shields.io/github/last-commit/infrae/pyoai)                                |
+| [pyoaiharvester](https://github.com/vphill/pyoaiharvester)                       | oai-pmh harvester CLI              | ![last-commit](https://img.shields.io/github/last-commit/vphill/pyoaiharvester)                       |
 | [ddblabs-ometha](https://github.com/Deutsche-Digitale-Bibliothek/ddblabs-ometha) | oai-pmh harvester with CLI and TUI | ![last-commit](https://img.shields.io/github/last-commit/Deutsche-Digitale-Bibliothek/ddblabs-ometha) |
-| [oai-harvest](https://github.com/bloomonkey/oai-harvest) | uses pyoai internally | ![last-commit](https://img.shields.io/github/last-commit/bloomonkey/oai-harvest) |
-| [oai-pmh-harvester](https://github.com/MITLibraries/oai-pmh-harvester) | uses sickle internally | ![last-commit](https://img.shields.io/github/last-commit/MITLibraries/oai-pmh-harvester) |
+| [oai-harvest](https://github.com/bloomonkey/oai-harvest)                         | uses pyoai internally              | ![last-commit](https://img.shields.io/github/last-commit/bloomonkey/oai-harvest)                      |
+| [oai-pmh-harvester](https://github.com/MITLibraries/oai-pmh-harvester)           | uses sickle internally             | ![last-commit](https://img.shields.io/github/last-commit/MITLibraries/oai-pmh-harvester)              |
 
-There are also similar projects available in [Java](https://github.com/topics/oai-pmh-client?l=java) and [PHP](https://github.com/topics/oai-pmh-client?l=php).
+There are also similar projects available in [Java](https://github.com/topics/oai-pmh-client?l=java) and
+[PHP](https://github.com/topics/oai-pmh-client?l=php).
 
 ## Acknowledgments
 
@@ -73,28 +77,29 @@ This is a fork of [sickle](https://github.com/mloesch/sickle) which was original
 
 oaipmh-scythe is distributed under the terms of the [BSD license](https://spdx.org/licenses/BSD-3-Clause.html).
 
-<!-- Markdown links -->
-[ci-workflow]: https://github.com/afuetterer/oaipmh-scythe/actions/workflows/main.yml
+<!-- Refs -->
+
+[all-downloads-badge]: https://static.pepy.tech/badge/oaipmh-scythe
 [ci-badge]: https://github.com/afuetterer/oaipmh-scythe/actions/workflows/main.yml/badge.svg
+[ci-workflow]: https://github.com/afuetterer/oaipmh-scythe/actions/workflows/main.yml
 [coverage-badge]: https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/afuetterer/fcb87d45f4d7defdfeffa65eb1d65f63/raw/coverage-badge.json
-[pre-commit-ci-status]: https://results.pre-commit.ci/latest/github/afuetterer/oaipmh-scythe/main
-[pre-commit-ci-badge]: https://results.pre-commit.ci/badge/github/afuetterer/oaipmh-scythe/main.svg
+[docs-badge]: https://github.com/afuetterer/oaipmh-scythe/actions/workflows/docs.yml/badge.svg
 [docs-url]: https://afuetterer.github.io/oaipmh-scythe
 [docs-workflow]: https://github.com/afuetterer/oaipmh-scythe/actions/workflows/docs.yml
-[docs-badge]: https://github.com/afuetterer/oaipmh-scythe/actions/workflows/docs.yml/badge.svg
-[scorecard-url]: https://securityscorecards.dev/viewer/?uri=github.com/afuetterer/oaipmh-scythe
-[scorecard-badge]: https://api.securityscorecards.dev/projects/github.com/afuetterer/oaipmh-scythe/badge
-[pypi-url]: https://pypi.org/project/oaipmh-scythe/
-[pypi-version-badge]: https://img.shields.io/pypi/v/oaipmh-scythe.svg?logo=pypi&label=PyPI
-[pepy-tech-url]: https://pepy.tech/project/oaipmh-scythe
-[all-downloads-badge]: https://static.pepy.tech/badge/oaipmh-scythe
-[monthly-downloads-badge]: https://static.pepy.tech/badge/oaipmh-scythe/month
-[pypi-python-versions-badge]: https://img.shields.io/pypi/pyversions/oaipmh-scythe.svg?logo=python&label=Python
-[license]: https://spdx.org/licenses/BSD-3-Clause.html
-[license-badge]: https://img.shields.io/badge/License-BSD_3--Clause-blue.svg
 [hatch]: https://github.com/pypa/hatch
 [hatch-badge]: https://img.shields.io/badge/%F0%9F%A5%9A-Hatch-4051b5.svg
-[ruff]: https://github.com/charliermarsh/ruff
-[ruff-badge]: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/charliermarsh/ruff/main/assets/badge/v2.json
+[license]: https://spdx.org/licenses/BSD-3-Clause.html
+[license-badge]: https://img.shields.io/badge/License-BSD_3--Clause-blue.svg
+[monthly-downloads-badge]: https://static.pepy.tech/badge/oaipmh-scythe/month
 [mypy]: https://mypy-lang.org
 [mypy-badge]: https://img.shields.io/badge/types-mypy-blue.svg
+[pepy-tech-url]: https://pepy.tech/project/oaipmh-scythe
+[pre-commit-ci-badge]: https://results.pre-commit.ci/badge/github/afuetterer/oaipmh-scythe/main.svg
+[pre-commit-ci-status]: https://results.pre-commit.ci/latest/github/afuetterer/oaipmh-scythe/main
+[pypi-python-versions-badge]: https://img.shields.io/pypi/pyversions/oaipmh-scythe.svg?logo=python&label=Python
+[pypi-url]: https://pypi.org/project/oaipmh-scythe/
+[pypi-version-badge]: https://img.shields.io/pypi/v/oaipmh-scythe.svg?logo=pypi&label=PyPI
+[ruff]: https://github.com/charliermarsh/ruff
+[ruff-badge]: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/charliermarsh/ruff/main/assets/badge/v2.json
+[scorecard-badge]: https://api.securityscorecards.dev/projects/github.com/afuetterer/oaipmh-scythe/badge
+[scorecard-url]: https://securityscorecards.dev/viewer/?uri=github.com/afuetterer/oaipmh-scythe

--- a/docs/customizing.md
+++ b/docs/customizing.md
@@ -1,21 +1,22 @@
-<!-- SPDX-FileCopyrightText: 2015 Mathias Loesch -->
-<!-- SPDX-FileCopyrightText: 2023 Heinz-Alexander Fütterer -->
+<!--
+SPDX-FileCopyrightText: 2015 Mathias Loesch
+SPDX-FileCopyrightText: 2023 Heinz-Alexander Fütterer
 
-<!-- SPDX-License-Identifier: BSD-3-Clause -->
+SPDX-License-Identifier: BSD-3-Clause
+-->
 
 # Harvesting other Metadata Formats than OAI-DC
 
-By default, oaipmh-scythe's mapping of the record XML into Python dictionaries
-is tailored to work only with Dublin-Core-encoded metadata payloads.
-Other formats most probably won't be mapped correctly, especially if
-they are more hierarchically structured than Dublin Core.
+By default, oaipmh-scythe's mapping of the record XML into Python dictionaries is tailored to work only with
+Dublin-Core-encoded metadata payloads. Other formats most probably won't be mapped correctly, especially if they are
+more hierarchically structured than Dublin Core.
 
-In case you want to harvest these more complex formats, you have to
-write your own record model class by subclassing the default
-implementation that unpacks the metadata XML:
+In case you want to harvest these more complex formats, you have to write your own record model class by subclassing the
+default implementation that unpacks the metadata XML:
 
 ```python
 from oaipmh_scythe.models import Record
+
 
 class MyRecord(Record):
     # Your XML unpacking implementation goes here.
@@ -23,28 +24,27 @@ class MyRecord(Record):
 ```
 
 !!! note
-    Take a look at the implementation of [oaipmh_scythe.models.Record][] to get an idea of
-    how to do this.
+    Take a look at the implementation of [oaipmh_scythe.models.Record][] to get an idea of how to do this.
 
-Next, associate your implementation with OAI verbs in the [oaipmh_scythe.client.Scythe][] object.
-In this case, we want the [oaipmh_scythe.client.Scythe][] object to use our implementation to represent items returned by
-ListRecords and GetRecord responses:
+Next, associate your implementation with OAI verbs in the [oaipmh_scythe.client.Scythe][] object. In this case, we want
+the [oaipmh_scythe.client.Scythe][] object to use our implementation to represent items returned by ListRecords and
+GetRecord responses:
 
 ```python
-scythe = Scythe('http://...')
-scythe.class_mapping['ListRecords'] = MyRecord
-scythe.class_mapping['GetRecord'] = MyRecord
+scythe = Scythe("http://...")
+scythe.class_mapping["ListRecords"] = MyRecord
+scythe.class_mapping["GetRecord"] = MyRecord
 ```
 
-If you need to rewrite *all* item implementations, you can also provide
-a complete mapping to the [oaipmh_scythe.client.Scythe][] object at instantiation:
+If you need to rewrite *all* item implementations, you can also provide a complete mapping to the
+[oaipmh_scythe.client.Scythe][] object at instantiation:
 
 ```python
 my_mapping = {
-    'ListRecords': MyRecord,
-    'GetRecord': MyRecord,
+    "ListRecords": MyRecord,
+    "GetRecord": MyRecord,
     # ...
 }
 
-scythe = Scythe('https://...', class_mapping=my_mapping)
+scythe = Scythe("https://...", class_mapping=my_mapping)
 ```

--- a/docs/oaipmh.md
+++ b/docs/oaipmh.md
@@ -1,20 +1,21 @@
-<!-- SPDX-FileCopyrightText: 2015 Mathias Loesch -->
-<!-- SPDX-FileCopyrightText: 2023 Heinz-Alexander Fütterer -->
+<!--
+SPDX-FileCopyrightText: 2015 Mathias Loesch
+SPDX-FileCopyrightText: 2023 Heinz-Alexander Fütterer
 
-<!-- SPDX-License-Identifier: BSD-3-Clause -->
+SPDX-License-Identifier: BSD-3-Clause
+-->
 
 # OAI-PMH Primer
 
-This section gives a basic overview of the [Open Archives Protocol for
-Metadata Harvesting (OAI-PMH)](https://openarchives.org/OAI/openarchivesprotocol.html). For more
-detailed information, please refer to the protocol specification.
+This section gives a basic overview of the
+[Open Archives Protocol for Metadata Harvesting (OAI-PMH)](https://openarchives.org/OAI/openarchivesprotocol.html). For
+more detailed information, please refer to the protocol specification.
 
 ## Glossary of Important OAI-PMH Concepts
 
 **Repository**
 
-A *repository* is a server-side application that exposes metadata
-    via OAI-PMH.
+A *repository* is a server-side application that exposes metadata via OAI-PMH.
 
 **Harvester**
 
@@ -22,9 +23,8 @@ OAI-PMH client applications like `oaipmh-scythe` are called *harvesters*.
 
 **record**
 
-A *record* is the XML-encoded container for the metadata of a single
-    publication item. It consists of a *header* and a *metadata*
-    section.
+A *record* is the XML-encoded container for the metadata of a single publication item. It consists of a *header* and a
+*metadata* section.
 
 **header**
 
@@ -32,8 +32,7 @@ The record *header* contains a unique identifier and a datestamp.
 
 **metadata**
 
-The record *metadata* contains the publication metadata in a defined
-    metadata format.
+The record *metadata* contains the publication metadata in a defined metadata format.
 
 **set**
 
@@ -41,13 +40,12 @@ A structure for grouping records for selective harvesting.
 
 **harvesting**
 
-The process of requesting records from the repository by the
-    harvester.
+The process of requesting records from the repository by the harvester.
 
 ## OAI Verbs
 
-OAI-PMH features six main API methods (so-called "OAI verbs") that can
-be issued by harvesters. Some verbs can be combined with further arguments:
+OAI-PMH features six main API methods (so-called "OAI verbs") that can be issued by harvesters. Some verbs can be
+combined with further arguments:
 
 `Identify`
 
@@ -62,16 +60,14 @@ Returns a single record. Arguments:
 
 `ListRecords`
 
-Returns the records in the repository in batches (possibly filtered
-    by a timestamp or a `set`). Arguments:
+Returns the records in the repository in batches (possibly filtered by a timestamp or a `set`). Arguments:
 
 - `metadataPrefix` (the prefix identifying the metadata format, *required*)
 - `from` (the earliest timestamp of the records, *optional*)
 - `until` (the latest timestamp of the records, *optional*)
 - `set` (a set for selective harvesting, *optional*)
-- `resumptionToken` (used for getting the next result batch if the
-    number of records returned by the previous request exceeds the
-    repository's maximum batch size, *exclusive*)
+- `resumptionToken` (used for getting the next result batch if the number of records returned by the previous request
+    exceeds the repository's maximum batch size, *exclusive*)
 
 `ListIdentifiers`
 
@@ -79,26 +75,19 @@ Returns the records in the repository in batches (possibly filtered
 
 `ListSets`
 
-Returns the list of sets supported by this repository. Arguments:
-    None
+Returns the list of sets supported by this repository. Arguments: None
 
 `ListMetadataFormats`
 
-Returns the list of metadata formats supported by this repository.
-    Arguments: None
+Returns the list of metadata formats supported by this repository. Arguments: None
 
 ## Metadata Formats
 
-OAI interfaces may expose metadata records in multiple metadata formats.
-These formats are identified by so-called "metadata prefixes". For
-instance, the prefix `oai_dc` refers to the OAI-DC format, which by
-definition has to be exposed by every valid OAI interface. OAI-DC is
-based on the 15 metadata elements specified in the [Dublin Core Metadata
-Element Set](http://dublincore.org/documents/dces/).
-
+OAI interfaces may expose metadata records in multiple metadata formats. These formats are identified by so-called
+"metadata prefixes". For instance, the prefix `oai_dc` refers to the OAI-DC format, which by definition has to be
+exposed by every valid OAI interface. OAI-DC is based on the 15 metadata elements specified in the
+[Dublin Core Metadata Element Set](http://dublincore.org/documents/dces/).
 
 !!! note
-
-    oaipmh-scythe only supports the OAI-DC format out of the box. See the section
-    on [customizing](customizing.md) for information on how to extend oaipmh-scythe
-    for retrieving metadata in other formats.
+    oaipmh-scythe only supports the OAI-DC format out of the box. See the section on [customizing](customizing.md) for
+    information on how to extend oaipmh-scythe for retrieving metadata in other formats.

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -1,7 +1,9 @@
-<!-- SPDX-FileCopyrightText: 2015 Mathias Loesch -->
-<!-- SPDX-FileCopyrightText: 2023 Heinz-Alexander Fütterer -->
+<!--
+SPDX-FileCopyrightText: 2015 Mathias Loesch
+SPDX-FileCopyrightText: 2023 Heinz-Alexander Fütterer
 
-<!-- SPDX-License-Identifier: BSD-3-Clause -->
+SPDX-License-Identifier: BSD-3-Clause
+-->
 
 # Tutorial
 
@@ -15,11 +17,11 @@ To make a connection to an OAI-PMH interface, you need to import the Scythe clas
 from oaipmh_scythe import Scythe
 ```
 
-We initialize the connection by passing it the base URL. In our example, we use the
-OAI-PMH interface of [Zenodo](https://zenodo.org/oai2d).
+We initialize the connection by passing it the base URL. In our example, we use the OAI-PMH interface of
+[Zenodo](https://zenodo.org/oai2d).
 
-It is recommended to use the Scythe class as a context manager to close established HTTP connections,
-when they are no longer needed.
+It is recommended to use the Scythe class as a context manager to close established HTTP connections, when they are no
+longer needed.
 
 ```python
 with Scythe("https://zenodo.org/oai2d") as scythe:
@@ -41,8 +43,8 @@ scythe.close()
 
 ## Issuing Requests
 
-oaipmh-scythe provides methods for each of the six OAI verbs (ListRecords,
-GetRecord, Identify, ListSets, ListMetadataFormats, ListIdentifiers).
+oaipmh-scythe provides methods for each of the six OAI verbs (ListRecords, GetRecord, Identify, ListSets,
+ListMetadataFormats, ListIdentifiers).
 
 Start with a ListRecords request:
 
@@ -50,26 +52,24 @@ Start with a ListRecords request:
 records = scythe.list_records()
 ```
 
-Note that all keyword arguments you provide to this function are passed
-to the OAI interface as HTTP parameters. Therefore, the example request
-would send the parameter `verb=ListRecord`.
+Note that all keyword arguments you provide to this function are passed to the OAI interface as HTTP parameters.
+Therefore, the example request would send the parameter `verb=ListRecord`.
 
 ## Performing Selective Harvesting
 
 ### Harvesting Records Based on Publication Date
 
-To selectively harvest records within a specific publication date range,
-the [list_records()][oaipmh_scythe.client.Scythe.list_records] and
-[list_identifiers()][oaipmh_scythe.client.Scythe.list_identifiers] methods of the Scythe client can be utilized
-with `from_` and `until` parameters. These parameters allow you to specify the lower and upper bounds
-of the desired date range, respectively. The accepted date format is YYYY-MM-DD (`str`).
+To selectively harvest records within a specific publication date range, the
+[list_records()][oaipmh_scythe.client.Scythe.list_records] and
+[list_identifiers()][oaipmh_scythe.client.Scythe.list_identifiers] methods of the Scythe client can be utilized with
+`from_` and `until` parameters. These parameters allow you to specify the lower and upper bounds of the desired date
+range, respectively. The accepted date format is YYYY-MM-DD (`str`).
 
-#### Using the from_ Parameter
+#### Using the from\_ Parameter
 
 The `from_` parameter (note the trailing underscore) is used to set the lower bound of the publication date range.
 
 !!! note
-
     The trailing underscore is necessary because `from` is a reserved keyword in Python.
 
 Example: Fetching Records Published On or After a Specific Date
@@ -97,7 +97,7 @@ next(records)
 
 This line will harvest records published up to and including January 17, 2024.
 
-#### Combining from_ and until
+#### Combining from\_ and until
 
 Both `from_` and `until` parameters can be used together to define a specific date range for harvesting records.
 
@@ -109,21 +109,20 @@ next(records)
 # <Record oai:zenodo.org:10517528>
 ```
 
-Here, `scythe.list_records(from_="2024-01-16", until="2024-01-17")` fetches records published between
-January 16 and January 17, 2024, inclusive.
+Here, `scythe.list_records(from_="2024-01-16", until="2024-01-17")` fetches records published between January 16 and
+January 17, 2024, inclusive.
 
 ### Harvesting Records based on Set Specification
 
-In addition to date-based filtering, the Scythe client offers the capability to selectively harvest records
-by specifying a set specification. This feature is particularly useful for fetching records that belong
-to a specific category or collection.
+In addition to date-based filtering, the Scythe client offers the capability to selectively harvest records by
+specifying a set specification. This feature is particularly useful for fetching records that belong to a specific
+category or collection.
 
-#### Using the set_ Parameter
+#### Using the set\_ Parameter
 
 The `set_` parameter allows you to specify a particular set of records for harvesting.
 
 !!! note
-
     It is important to note the trailing underscore in `set_`. This is used because `set` is a reserved keyword in Python.
 
 Example: Fetching records from a specific set
@@ -134,16 +133,16 @@ next(records)
 # <Record oai:zenodo.org:32712>
 ```
 
-In this example, `scythe.list_records(set_="software")` retrieves records that are part of the 'software' set.
-The call to `next(records)` fetches the first record from the retrieved set.
+In this example, `scythe.list_records(set_="software")` retrieves records that are part of the 'software' set. The call
+to `next(records)` fetches the first record from the retrieved set.
 
-#### Considerations when using the set_ Parameter
+#### Considerations when using the set\_ Parameter
 
-Set Identifier: The value passed to the `set_` parameter should match the identifier used by the OAI-PMH service
-for the desired set. These identifiers are often predefined by the data provider and should be used as documented.
+Set Identifier: The value passed to the `set_` parameter should match the identifier used by the OAI-PMH service for the
+desired set. These identifiers are often predefined by the data provider and should be used as documented.
 
-Combining with Other Parameters: The `set_` parameter can be combined with other parameters like `from_` and `until`
-for more refined filtering. This allows for fetching records from a specific set within a certain date range.
+Combining with Other Parameters: The `set_` parameter can be combined with other parameters like `from_` and `until` for
+more refined filtering. This allows for fetching records from a specific set within a certain date range.
 
 Example: Combining `set_` with Date Filters
 
@@ -157,14 +156,14 @@ This code will harvest records from the 'software' set that were published in Ja
 
 ### Default Metadata Format and Specifying Custom Formats
 
-When harvesting records using the `Scythe` client, it's important to understand how metadata formats are handled.
-By default, if no specific metadata format is provided, `Scythe` retrieves records in the `oai_dc` format.
-This format is universally supported by all OAI-PMH repositories, ensuring broad compatibility.
+When harvesting records using the `Scythe` client, it's important to understand how metadata formats are handled. By
+default, if no specific metadata format is provided, `Scythe` retrieves records in the `oai_dc` format. This format is
+universally supported by all OAI-PMH repositories, ensuring broad compatibility.
 
 #### Default Behavior: Harvesting in oai_dc Format
 
-If you do not specify a metadata format, scythe will automatically use the "oai_dc" metadata format.
-This is the Dublin Core format, a standard for simple and generic metadata representation.
+If you do not specify a metadata format, scythe will automatically use the "oai_dc" metadata format. This is the Dublin
+Core format, a standard for simple and generic metadata representation.
 
 Example: Fetching records with default metadata format
 
@@ -199,16 +198,14 @@ records = scythe.list_records(metadata_prefix="datacite")
 In this example, `scythe.list_records(metadata_prefix="datacite")` retrieves records in the "datacite" metadata format.
 
 !!! note
-
-    It's important to remember that in the absence of a specified `metadata_prefix`, scythe will default to using
-    the "oai_dc" format. This ensures that you can always retrieve records even if the specific format
-    requirements are not known.
+    It's important to remember that in the absence of a specified `metadata_prefix`, scythe will default to using the
+    "oai_dc" format. This ensures that you can always retrieve records even if the specific format requirements are not
+    known.
 
 ## Consecutive Harvesting
 
-Since most OAI verbs yield more than one element, their respective
-Scythe methods return iterator objects which can be used to iterate over
-the records of a repository:
+Since most OAI verbs yield more than one element, their respective Scythe methods return iterator objects which can be
+used to iterate over the records of a repository:
 
 ```python
 records = scythe.list_records()
@@ -216,13 +213,13 @@ next(records)
 # <Record oai:zenodo.org:4574771>
 ```
 
-Note that this works with all verbs that return more than one element.
-These are: [list_records()][oaipmh_scythe.client.Scythe.list_records],
-[list_identifiers()][oaipmh_scythe.client.Scythe.list_identifiers], [list_sets()][oaipmh_scythe.client.Scythe.list_sets],
-and [list_metadata_formats()][oaipmh_scythe.client.Scythe.list_metadata_formats].
+Note that this works with all verbs that return more than one element. These are:
+[list_records()][oaipmh_scythe.client.Scythe.list_records],
+[list_identifiers()][oaipmh_scythe.client.Scythe.list_identifiers],
+[list_sets()][oaipmh_scythe.client.Scythe.list_sets], and
+[list_metadata_formats()][oaipmh_scythe.client.Scythe.list_metadata_formats].
 
-The following example shows how to iterate over the headers returned by
-`list_identifiers()`:
+The following example shows how to iterate over the headers returned by `list_identifiers()`:
 
 ```python
 headers = scythe.list_identifiers()
@@ -238,8 +235,8 @@ next(sets)
 # <Set European Middleware Initiative>
 ```
 
-To explore all the metadata formats supported by the repository, you can iterate through the formats returned
-by the `list_metadata_formats()` method:
+To explore all the metadata formats supported by the repository, you can iterate through the formats returned by the
+`list_metadata_formats()` method:
 
 ```python
 metadata_formats = scythe.list_metadata_formats()
@@ -258,15 +255,15 @@ scythe.get_record(identifier="oai:zenodo.org:4574771")
 
 ## Harvesting OAI Items vs. OAI Responses
 
-Scythe supports two harvesting modes that differ in the type of the
-returned objects. The default mode returns OAI-specific *items*
-(records, headers etc.) encoded as Python objects as seen earlier. If
-you want to save the whole XML response returned by the server, you have
-to pass the [OAIResponseIterator][oaipmh_scythe.iterator.OAIResponseIterator] during the instantiation of the
+Scythe supports two harvesting modes that differ in the type of the returned objects. The default mode returns
+OAI-specific *items* (records, headers etc.) encoded as Python objects as seen earlier. If you want to save the whole
+XML response returned by the server, you have to pass the
+[OAIResponseIterator][oaipmh_scythe.iterator.OAIResponseIterator] during the instantiation of the
 [Scythe][oaipmh_scythe.client.Scythe] object:
 
 ```python
 from oaipmh_scythe.iterator import OAIResponseIterator
+
 scythe = Scythe("https://zenodo.org/oai2d", iterator=OAIResponseIterator)
 responses = scythe.list_records()
 next(responses)
@@ -283,14 +280,14 @@ with open("response.xml", "w") as f:
 ## Ignoring Deleted Records
 
 The [list_records()][oaipmh_scythe.client.Scythe.list_records] and
-[list_identifiers()][oaipmh_scythe.client.Scythe.list_identifiers] methods accept an optional parameter `ignore_deleted`.
-If set to `True`, the returned [OAIItemIterator][oaipmh_scythe.iterator.OAIItemIterator] will skip deleted records/headers:
+[list_identifiers()][oaipmh_scythe.client.Scythe.list_identifiers] methods accept an optional parameter
+`ignore_deleted`. If set to `True`, the returned [OAIItemIterator][oaipmh_scythe.iterator.OAIItemIterator] will skip
+deleted records/headers:
 
 ```python
 records = scythe.list_records(ignore_deleted=True)
 ```
 
 !!! note
-
     This works only using the [oaipmh_scythe.iterator.OAIItemIterator][]. If you use the
     [oaipmh_scythe.iterator.OAIResponseIterator][], the resulting OAI responses will still contain the deleted records.


### PR DESCRIPTION
Fixes: #276

- [x] manually reformat the SPDX copyright headers
- [x] --number
- [x] --ignore-missing-references
- [x] use mdformat-mkdocs v2.0.7
- [x] --wrap=120
- [x] comments in pr template
- [x] comments in issue templates
