### PR TITLE
build: fix hatch release env

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,7 @@ deploy = "mkdocs gh-deploy --force --config-file=docs/mkdocs.yml"
 
 [tool.hatch.envs.release]
 features = ["release"]
+template = "release"
 [tool.hatch.envs.release.scripts]
 next-version = "semantic-release version --print"
 update-citation = """


### PR DESCRIPTION
CI was broken, because of not being able to run `hatch run release:update-citation`.