### PR TITLE
ci: fix docs workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -76,6 +76,7 @@ jobs:
         enable-cache: true
         prune-cache: false
         cache-suffix: docs
+    - run: uv lock --upgrade # we need to bump the version of oaipmh-scythe in uv.lock as well
     - run: just sync-docs
     - run: just docs-deploy
       env:

--- a/uv.lock
+++ b/uv.lock
@@ -908,7 +908,7 @@ wheels = [
 
 [[package]]
 name = "oaipmh-scythe"
-version = "0.13.0"
+version = "0.14.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request, so you do not need to remove them. --->

<!--- Provide a general summary of your changes in the Title above --->

## Description

This fixes the broken docs workflow when publishing a release. Using `UV_LOCKED` in the justfile leads to an error, about an outdated lockfile.