### PR TITLE
perf: pre-compile regex pattern in get_namespace

### DIFF
--- a/src/oaipmh_scythe/utils.py
+++ b/src/oaipmh_scythe/utils.py
@@ -86,6 +86,9 @@ def filter_dict_except_resumption_token(d: dict[str, Any | None]) -> dict[str, A
     return d
 
 
+NAMESPACE_PATTERN = re.compile(r"(\{.*\})")
+
+
 def get_namespace(element: etree._Element) -> str | None:
     """Return the namespace URI of an XML element.
 
@@ -99,7 +102,7 @@ def get_namespace(element: etree._Element) -> str | None:
     Returns:
         The namespace URI as a string if the element has a namespace, otherwise `None`.
     """
-    match = re.search(r"(\{.*\})", element.tag)
+    match = NAMESPACE_PATTERN.search(element.tag)
     return match.group(1) if match else None
 
 


### PR DESCRIPTION
## Description

Pre-compile the namespace regex pattern at module load time to avoid recompilation overhead on every function call. This improves performance when processing large XML files or calling the function frequently.
