### PR TITLE
build: fix build command in prs config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -177,8 +177,10 @@ build_command = """
 sed -i "s/^version: .*/version: $NEW_VERSION/" CITATION.cff
 sed -i "s/^date-released: .*/date-released: $(date "+%Y-%m-%d")/" CITATION.cff
 git add CITATION.cff
-python -m pip install "build[uv]"
-python -m build --installer=uv
+python -m pip install uv
+uv lock --upgrade-package "$PACKAGE_NAME"
+git add uv.lock
+uv build
 """
 changelog.template_dir = ".github/templates"
 changelog.environment.keep_trailing_newline = true


### PR DESCRIPTION
## Description

This PR fixes the build command in the PSR config. The version of oaimph-scythe needs to get bumped in the uv.lock file during a release, otherwise subsequent CI runs start to fail.

Ref: https://python-semantic-release.readthedocs.io/en/latest/configuration/configuration-guides/uv_integration.html


## Motivation and context

<!--- Why is this change required? What problem does it solve? --->

## How has this been tested?

<!---
Please describe in detail how you tested your changes.

Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.
--->

## Checklist

<!---
Go over all the following points, and remove the lines, that do not apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
--->

- I have read the [contributor guide](https://github.com/afuetterer/oaipmh-scythe/blob/main/.github/CONTRIBUTING.md).
- My code follows the code style of this project.
- My change requires a change to the documentation.
- I have updated the documentation accordingly.
- I have added tests to cover my changes.

<!---
This pull request template is adapted from:
"open-source-templates", https://github.com/TalAter/open-source-templates (MIT License).
"amazing-github-template", https://github.com/dec0dOS/amazing-github-template (MIT License).
--->
