### PR TITLE
build: fix build command in prs config again

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,7 +178,7 @@ sed -i "s/^version: .*/version: $NEW_VERSION/" CITATION.cff
 sed -i "s/^date-released: .*/date-released: $(date "+%Y-%m-%d")/" CITATION.cff
 git add CITATION.cff
 python -m pip install uv
-uv lock --upgrade-package "$PACKAGE_NAME"
+uv lock --upgrade-package "$PACKAGE_NAME" --exclude-newer="1 week"
 git add uv.lock
 uv build
 """

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,10 @@ version = 1
 revision = 3
 requires-python = ">=3.10"
 
+[options]
+exclude-newer = "2026-04-04T17:23:21.18002113Z"
+exclude-newer-span = "P1W"
+
 [[package]]
 name = "anyio"
 version = "4.13.0"


### PR DESCRIPTION
## Description

CI failed the docs workflow after a release. There was still a mismatch between the uv.lock files.
