### PR TITLE
chore: remove pip section from dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,14 +16,3 @@ updates:
     github-actions:
       patterns:
       - '*'
-- package-ecosystem: pip
-  directory: /
-  schedule:
-    interval: quarterly
-  versioning-strategy: increase-if-necessary
-  commit-message:
-    prefix: build
-    include: scope
-  labels:
-  - 'type: build'
-  - 'deps: python'


### PR DESCRIPTION
## Description

We update the uv.lock regurlarly. Our python dependencies do not need to be monitored individually be dependabot anymore.

