### PR TITLE
ci: add test for python 3.15

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,8 +33,11 @@ jobs:
     runs-on: ubuntu-26.04
     strategy:
       matrix:
-        python-version: ['3.10', '3.12', '3.14']
+        python-version: ['3.10', '3.12', '3.14', '3.15']
     steps:
+    - name: Install system dependencies needed to build lxml
+      if: matrix.python-version == '3.15'
+      run: sudo apt-get update && sudo apt-get install --yes libxml2-dev libxslt1-dev
     - name: Set up just
       uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0


### PR DESCRIPTION
This PR tests the library against Python 3.15.0rc1.

lxml needs to be built from source. We need to have libxml2-dev and libxslt1-dev system libraries available.